### PR TITLE
Change base image to debian

### DIFF
--- a/setup-aiverify/aiverify-user/Dockerfile
+++ b/setup-aiverify/aiverify-user/Dockerfile
@@ -1,6 +1,6 @@
 # Build the aiverify docker image
 
-FROM ubuntu:22.04
+FROM debian:12
 
 ###################  Install libraries ######################
 
@@ -17,40 +17,11 @@ RUN apt-get update && apt-get install -y nodejs
 
 # Install python 3.11, virtualenv
 RUN apt-get update
-RUN apt install software-properties-common -y
-RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get install -y python3.11 python3.11-venv
 
 ###################  Install chromium ######################
 
-# Install Chromium (for puppeteer) separately to cater for arm64 and amd64,
-# as puppeteer installs Chrome/Chromium for amd64 only
-RUN apt-get install debian-archive-keyring
-
-RUN umask 22
-
-RUN echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian stable main\n \
-deb-src [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian stable main\n \
-\n \
-deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian-security/ stable-security main\n \
-deb-src [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian-security/ stable-security main\n \
-\n \
-deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian stable-updates main\n \
-deb-src [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian stable-updates main' | tee /etc/apt/sources.list.d/debian-stable.list
-
-RUN echo 'Package: chromium*\n \
-Pin: origin *.debian.org\n \
-Pin-Priority: 100\n \
-\n \
-Package: *\n \
-Pin: origin *.debian.org\n \
-Pin-Priority: 1' | tee /etc/apt/preferences.d/debian-chromium
-
-RUN apt-get update
-
-RUN apt-get install chromium -y
-
-RUN ln -s /usr/bin/chromium /usr/bin/chromium-browser
+RUN apt-get install chromium -y && ln -s /usr/bin/chromium /usr/bin/chromium-browser
 
 # Install NPM
 RUN apt-get install npm -y


### PR DESCRIPTION
## Description

Changed the base image from ubuntu:22.04 to debian:12

## Motivation and Context

puppeter is one of the dependency of aiverify, and require the installation of chromium as its dependency. However, puppeter currently does not support the installation of chromium on amd64 platform (See https://github.com/puppeteer/puppeteer/issues/7740). This means that we would need to install chromium manually on the operating system level, which should install the appropriate binary based on the arch. 

Unfortunately, ubuntu currently uses snap to install chromium browser on amd64. Clearly, we would not be able to use snap in the context of a docker build. 

Currently, the implementation uses ubuntu as a base image, but uses the debian repo to install chromium (debian provides a amd64 arch build of chromium). However, this may result slightly different versions of the other packages, which may lead to inconsistent builds. Crucially, we now need to be careful of the order which we install packages; some packages may need to be installed before/after adding the debian repos.

Since ubuntu and debian are fairly close, we can explore the use of debian as a base image instead.

## Type of Change

<!-- Select the appropriate type of change: -->
<!-- - feat: A new feature -->
<!-- - fix: A bug fix -->
<!-- - chore: Routine tasks, maintenance, or tooling changes -->
<!-- - docs: Documentation updates -->
<!-- - style: Code style changes (e.g., formatting, indentation) -->
<!-- - refactor: Code refactoring without changes in functionality -->
<!-- - test: Adding or modifying tests -->
<!-- - perf: Performance improvements -->
<!-- - ci: Changes to the CI/CD configuration or scripts -->
- other: Other changes that don't fit into the above categories

## How to Test

I've tested the build and am able to run the portal/test-engine services. However, I'm not sure if existing functionalities may be affected. Would appreciate help in verifying that the change did not introduce any regressions.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [ ]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

### Python3.11

debian:12 currently has the python3.11 packages. The build now uses the debian packages, instead of the `ppa:deadsnakes/ppa` ppa

Do note that the `ppa:deadsnakes/ppa` ppa is meant for ubuntu, and is not supported on debian. This means that in future, there may be additional changes if there is a need to use a newer version of python than is provided by the debian repo.

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
