### PR TITLE
Dockerfile for Robustness Toolbox (#357)

### DIFF
--- a/stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox/Dockerfile
+++ b/stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.11-slim
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y git gcc
+
+# Install HDF5 using apt
+RUN apt-get update && apt-get install -y libhdf5-dev pkg-config
+
+RUN pip install --upgrade pip
+RUN pip install --no-binary h5py h5py
+
+WORKDIR /app/aiverify
+
+# Copy test engine core folder to install requirements; in future we can install the test-engine-core pypi package
+COPY aiverify-test-engine ./aiverify-test-engine
+
+# Copy sample data to run pytest
+COPY stock-plugins/user_defined_files ./stock-plugins/user_defined_files
+
+# Copy algorithm folder
+COPY stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox ./stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox
+
+# Install algorithm requirements
+WORKDIR /app/aiverify/stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox
+RUN pip install pytest
+RUN pip install -e '.[dev]'
+
+ENTRYPOINT ["python3", "-m", "aiverify_robustness_toolbox"]
+

--- a/stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox/README.md
+++ b/stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox/README.md
@@ -69,3 +69,41 @@ Run the following steps to execute the unit and integration tests inside the `te
 cd aiverify/stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox
 pytest .
 ```
+
+## Run using Docker
+In the aiverify root directory, run the below command to build the docker image
+```sh
+docker build -t aiverify-robustness-toolbox:v2.0.0a1 -f stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox/Dockerfile .
+```
+
+Switch to the algorithm directory
+```sh
+cd stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox/
+```
+
+Run the below bash script to run the algorithm
+```sh
+#!/bin/bash
+
+root_path="<PATH_TO_FOLDER>/aiverify/stock-plugins/user_defined_files"
+docker run \
+  -v $root_path:/user_defined_files \
+  -v ./output:/app/aiverify/stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox/output \
+  aiverify-robustness-toolbox:v2.0.0a1 \
+  --data_path /user_defined_files/data/raw_fashion_image_10 \
+  --model_path /user_defined_files/pipeline/multiclass_classification_image_mnist_fashion \
+  --ground_truth_path /user_defined_files/data/pickle_pandas_fashion_mnist_annotated_labels_10.sav \
+  --ground_truth label \
+  --model_type CLASSIFICATION \
+  --run_pipeline \
+  --annotated_ground_truth_path /user_defined_files/data/pickle_pandas_fashion_mnist_annotated_labels_10.sav \
+  --file_name_label file_name
+```
+If the algorithm runs successfully, the results of the test will be saved in an `output` folder in the algorithm directory.
+
+## Tests
+### Pytest is used as the testing framework.
+Run the following steps to execute the unit and integration tests inside the `tests/` folder
+```sh
+docker run --entrypoint python3 aiverify-robustness-toolbox:v2.0.0a1 -m pytest .
+```


### PR DESCRIPTION
## Description

Added dockerfile to run robustness toolbox
Volume mounts to local folders to access data and model files, and to view output/results.json
Currently cloning test-engine-core folder to install requirements; in future can pip install test-engine-core

## Type of Change

Feat: Allow developers to run algorithm as a docker image

## How to Test

After building the image, execute the command to run the existing unit and e2e tests:
```
docker run --entrypoint python3 aiverify-robustness-toolbox:v2.0.0a1 -m pytest .
```

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [x]  I have added or updated the necessary documentation (README, API docs, etc.).
- [x]  I have added appropriate unit tests or functional tests for the changes made.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [x]  I have squashed or reorganized my commits into logical units.
- [x]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/c3220d17-2626-445e-8e7c-1f02b8761367)

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
