### PR TITLE
Fix: Return mock data for widget bundle in APIGW

### DIFF
--- a/aiverify-apigw/aiverify_apigw/lib/plugin_store.py
+++ b/aiverify-apigw/aiverify_apigw/lib/plugin_store.py
@@ -302,7 +302,7 @@ class PluginStore:
 
                 session.expunge(plugin)
                 return plugin
-
+    
     @classmethod
     def scan_plugin_directory(cls, folder: Path, temp_dir: Path, is_stock: bool = False):
         """Scan the plugin directory and save the plugin information to DB.
@@ -399,6 +399,15 @@ class PluginStore:
                 for meta_file in meta_files:
                     meta, meta_json = cls.validate_widget(widget_path=widgets_subdir,
                                                           meta_path=meta_file, folder=mdx_bundle_folder)
+                    # Process mock data for widgets if present
+                    if meta.mockdata:
+                        for mock_entry in meta.mockdata:
+                            if mock_entry.datapath:
+                                mock_file = widgets_subdir.joinpath(mock_entry.datapath)
+                                if mock_file.exists():
+                                    with open(mock_file, 'r') as f:
+                                        mock_entry.data = json.load(f)
+                                        meta_json['mockdata'] = [m.model_dump() for m in meta.mockdata]
                     if meta.dependencies:
                         dependencies = [dep.model_dump_json() for dep in meta.dependencies]
                         # dependencies = [
@@ -420,7 +429,7 @@ class PluginStore:
                         properties=json.dumps([prop.model_dump_json() for prop in meta.properties]
                                               ).encode("utf-8") if meta.properties else None,
                         mockdata=json.dumps([md.model_dump_json() for md in meta.mockdata]
-                                            ).encode("utf-8") if meta.mockdata else None,
+                                        ).encode("utf-8") if meta.mockdata else None,
                         dynamic_height=meta.dynamicHeight,
                         dependencies=json.dumps(dependencies).encode('utf-8'),
                     )

--- a/aiverify-apigw/aiverify_apigw/lib/plugin_store.py
+++ b/aiverify-apigw/aiverify_apigw/lib/plugin_store.py
@@ -304,6 +304,39 @@ class PluginStore:
                 return plugin
     
     @classmethod
+    def validate_mock_data_path(base_dir: Path, datapath: str) -> bool:
+        """
+        Validate that the mock data file exists and is within the allowed directory.
+        
+        Args:
+            base_dir (Path): Base plugin directory (widget or input block directory)
+            datapath (str): Relative path to mock data file
+        
+        Returns:
+            bool: True if path is valid, False otherwise
+        """
+        try:
+            # Convert datapath to Path object
+            data_file = Path(datapath)
+            
+            # Resolve the absolute path of the mock data file
+            full_path = (base_dir / data_file).resolve()
+            base_resolved = base_dir.resolve()
+            
+            # Check if:
+            # 1. The path exists
+            # 2. It's a file
+            # 3. It's within the base directory (prevent directory traversal)
+            return (
+                full_path.exists() and 
+                full_path.is_file() and 
+                base_resolved in full_path.parents
+            )
+        except Exception as e:
+            logger.error(f"Error validating mock data path: {str(e)}")
+            return False
+    
+    @classmethod
     def scan_plugin_directory(cls, folder: Path, temp_dir: Path, is_stock: bool = False):
         """Scan the plugin directory and save the plugin information to DB.
         Assume that the directory has been validated using validate_plugin_directory.
@@ -401,13 +434,30 @@ class PluginStore:
                                                           meta_path=meta_file, folder=mdx_bundle_folder)
                     # Process mock data for widgets if present
                     if meta.mockdata:
+                        valid_mock_data = []
                         for mock_entry in meta.mockdata:
-                            if mock_entry.datapath:
-                                mock_file = widgets_subdir.joinpath(mock_entry.datapath)
-                                if mock_file.exists():
-                                    with open(mock_file, 'r') as f:
+                            if not hasattr(mock_entry, 'datapath'):
+                                logger.warning(f"Mock data entry missing datapath in widget {meta.cid}")
+                                continue
+                                
+                            # Validate the mock data path using the static method
+                            if cls.validate_mock_data_path(widgets_subdir, mock_entry.datapath):
+                                try:
+                                    with open(widgets_subdir / mock_entry.datapath, 'r') as f:
                                         mock_entry.data = json.load(f)
-                                        meta_json['mockdata'] = [m.model_dump() for m in meta.mockdata]
+                                    valid_mock_data.append(mock_entry)
+                                except Exception as e:
+                                    logger.error(f"Error reading mock data file for widget {meta.cid}: {str(e)}")
+                            else:
+                                logger.warning(
+                                    f"Invalid mock data path '{mock_entry.datapath}' "
+                                    f"for widget {meta.cid}"
+                                )
+                        
+                        # Update meta_json with valid mock data only
+                        meta.mockdata = valid_mock_data
+                        meta_json['mockdata'] = [m.model_dump() for m in valid_mock_data]
+                        
                     if meta.dependencies:
                         dependencies = [dep.model_dump_json() for dep in meta.dependencies]
                         # dependencies = [

--- a/aiverify-apigw/aiverify_apigw/routers/plugin_router.py
+++ b/aiverify-apigw/aiverify_apigw/routers/plugin_router.py
@@ -1,3 +1,4 @@
+import json
 from fastapi import APIRouter, HTTPException, Depends, UploadFile, File, Response
 from fastapi.responses import JSONResponse
 from typing import List
@@ -10,7 +11,7 @@ from ..lib.filestore import get_plugin_zip, get_plugin_algorithm_zip, backup_plu
 from ..lib.plugin_store import PluginStore, PluginStoreException
 from ..lib.file_utils import sanitize_filename
 from ..schemas import PluginOutput
-from ..models import PluginModel, AlgorithmModel
+from ..models import PluginModel, AlgorithmModel, WidgetModel
 
 router = APIRouter(prefix="/plugins", tags=["plugin"])
 
@@ -314,6 +315,30 @@ async def download_plugin_bundle(gid: str, cid: str, session: Session = Depends(
 
         if not plugin:
             raise HTTPException(status_code=404, detail="Plugin not found")
+        
+        widget_stmt = select(WidgetModel).filter_by(gid=gid, cid=cid.split(':')[-1])
+        widget = session.scalar(widget_stmt)
+        
+        if widget:
+            # Get the bundle
+            bundle = get_plugin_mdx_bundle(gid, cid)
+            resp_obj = {key: bundle[key] for key in ['code', 'frontmatter']}
+            
+            # Add mock data if available
+            if widget.mockdata:
+                try:
+                    mock_data = json.loads(widget.mockdata.decode('utf-8'))
+                    # Include the actual data from the mockdata field
+                    resp_obj['mockData'] = mock_data
+                except json.JSONDecodeError:
+                    logger.error(f"Failed to decode mock data for widget {cid}")
+            
+            return JSONResponse(content=resp_obj)
+        
+        # If not a widget, just return the bundle as before
+        bundle = get_plugin_mdx_bundle(gid, cid)
+        resp_obj = {key: bundle[key] for key in ['code', 'frontmatter']}
+        return JSONResponse(content=resp_obj)
 
         # Call the get_plugin_zip method from filestore to create the zip file
         bundle = get_plugin_mdx_bundle(gid, cid)


### PR DESCRIPTION
## Description

API Call '{gid}/bundle/{cid}' now returns mock data under 'mockData' if it exists.

## Motivation and Context

Previously, mock data was not read in plugin_store.py and no mock data was returned.

## Type of Change

1. For each widget meta, validate datapath exists and under the temporary plugin directory
2. Read in the actual json data based on the data path and save the data under the mockdata field as data

Update the plugin_router.py file, under "/{gid}/bundle/{cid}" route:
1. Add check for valid cid with the plugin database record
2. If cid is a widget, return mockdata in the JSON response

## How to Test

1. Run the API Gateway
2. Test `GET /{gid}/bundle/{cid}` to see if `mockData` field is returned for widgets with mock data in the stock plugins. Plugins/widgets that do not have mock data only returns `code` and `frontmatter`.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [ ]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [ ]  I have performed a self-review of my own code.
- [ ]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
