### PR TITLE
fixed bug in apigw for mockdata

### DIFF
--- a/aiverify-apigw/aiverify_apigw/lib/plugin_store.py
+++ b/aiverify-apigw/aiverify_apigw/lib/plugin_store.py
@@ -304,7 +304,7 @@ class PluginStore:
                 return plugin
     
     @classmethod
-    def validate_mock_data_path(base_dir: Path, datapath: str) -> bool:
+    def validate_mock_data_path(cls, base_dir: Path, datapath: str) -> bool:
         """
         Validate that the mock data file exists and is within the allowed directory.
         

--- a/aiverify-apigw/aiverify_apigw/schemas/widget.py
+++ b/aiverify-apigw/aiverify_apigw/schemas/widget.py
@@ -92,11 +92,18 @@ class WidgetOutput (WidgetMeta):
             try:
                 mock_data_list = json.loads(result.mockdata.decode('utf-8'))
                 mockdata = []
-                for mock in mock_data_list:
-                    # Ensure the data field is passed through as-is without type validation
-                    if 'data' in mock:
-                        mock['data'] = json.loads(mock['data']) if isinstance(mock['data'], str) else mock['data']
-                    mockdata.append(WidgetMetaMockData.model_validate(mock))
+                for mock_item in mock_data_list:
+                    if isinstance(mock_item, str):
+                        mock_item = json.loads(mock_item)
+                    
+                    if 'data' in mock_item:
+                        if isinstance(mock_item['data'], str):
+                            try:
+                                mock_item['data'] = json.loads(mock_item['data'])
+                            except json.JSONDecodeError:
+                                pass
+                    
+                    mockdata.append(WidgetMetaMockData.model_validate(mock_item))
             except Exception as e:
                 import logging
                 logging.error(f"Error parsing mock data for widget {result.cid}: {str(e)}")


### PR DESCRIPTION
## Description

fixed bug for apigw for '{gid}/bundle/{cid}' to include mockdata

## Motivation and Context

[Explain the motivation or the context behind this pull request. Why is it necessary?]

## Type of Change


## How to Test

1. set up apigw
2. test out the GET '{gid}/bundle/{cid}' to see if mockdata is returned if it exists for the widget

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [ ]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [ ]  I have performed a self-review of my own code.
- [ ]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
