### PR TITLE
fix: Avoid deep copying in `ModelContainer` to resolve pickling errors

### DIFF
--- a/stock-plugins/aiverify.stock.veritas/algorithms/veritastool/aiverify_veritastool/algo.meta.json
+++ b/stock-plugins/aiverify.stock.veritas/algorithms/veritastool/aiverify_veritastool/algo.meta.json
@@ -7,7 +7,7 @@
         "regression",
         "uplift"
     ],
-    "version": "2.0.0a2",
+    "version": "2.0.0a3",
     "author": "AI Verify",
     "description": "Veritas Diagnosis tool for fairness & transparency assessment.",
     "tags": [

--- a/stock-plugins/aiverify.stock.veritas/algorithms/veritastool/aiverify_veritastool/model/model_container.py
+++ b/stock-plugins/aiverify.stock.veritas/algorithms/veritastool/aiverify_veritastool/model/model_container.py
@@ -28,6 +28,7 @@ class ModelContainer(object):
         x_train=None,
         x_test=None,
         model_object=None,
+        model_objects=None,
         up_grp=None,
         predict_proba_op_name="predict_proba",
     ):
@@ -106,6 +107,9 @@ class ModelContainer(object):
         model_object : object
                 A blank model object used in the feature importance section for training and prediction.
 
+        model_objects : list of model object
+                Blank model objects used in the feature importance section for training and prediction.
+
         _input_validation_lookup : dictionary
                 Contains the attribute, its correct data type and values (if it is applicable) for every argument passed by user.
 
@@ -157,6 +161,7 @@ class ModelContainer(object):
             self.p_grp_input = None
         self.protected_features_cols = protected_features_cols
         self.model_object = model_object
+        self.model_objects = model_objects
         self.train_op_name = train_op_name
         self.predict_op_name = predict_op_name
         self.predict_proba_op_name = predict_proba_op_name

--- a/stock-plugins/aiverify.stock.veritas/algorithms/veritastool/aiverify_veritastool/principles/fairness.py
+++ b/stock-plugins/aiverify.stock.veritas/algorithms/veritastool/aiverify_veritastool/principles/fairness.py
@@ -4197,8 +4197,12 @@ class Fairness:
         model_objects = []
         for i in range(len(self.model_params)):
             model_param = copy.copy(self.model_params[i])
-            model_obj = getattr(model_param, "model_object")
-            setattr(model_param, "model_object", deepcopy(model_obj))
+            model_obj = getattr(model_param, "model_object", None)
+            if hasattr(model_param, 'model_objects') and model_param.model_objects:
+                model_object = model_param.model_objects.pop(0)
+            else:
+                model_object = deepcopy(model_obj)
+            setattr(model_param, "model_object", model_object)
             model_objects.append(model_param.model_object)
         return model_objects
 


### PR DESCRIPTION
## Description

This pull request introduces a new `model_objects` parameter in the `ModelContainer` class, allowing users to pass pre-created model objects directly. The primary change eliminates the need for deep copying `model_object`, which previously caused `"cannot pickle"` errors when dealing with non-serializable objects, such as those from Driverless AI. Instead, the updated implementation checks for a `model_objects` list and assigns a model instance from it, ensuring seamless integration with existing tools.

## Motivation and Context
The original implementation relied on deep copying experiment objects, leading to serialization issues when handling non-picklable objects. This limitation prevented users from effectively integrating their models, particularly when using community-standard tools. By introducing the `model_objects` parameter, this update resolves the serialization issue while maintaining backward compatibility with the existing single `model_object` approach.

## Type of Change

 fix: A bug fix

## How to Test

1. Create a `ModelContainer` instance including the `model_object` parameter along with the new `model_objects` parameter with a pre-created list of `model_object` objects.  
2. Create a use case object that utilizes the `ModelContainer` instance.  
3. Run fairness and feature importance analysis for the created use case object.  
4. Validate that no `"cannot pickle"` errors occur when interacting with Driverless AI objects.  
5. Verify that the original functionality remains intact when only using the single `model_object` without the `model_objects` parameter. 

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [ ]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [ ]  I have performed a self-review of my own code.
- [ ]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

N/A

## Additional Notes

This change ensures that non-picklable objects can be utilized without requiring workarounds, improving compatibility with community tools and frameworks.

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
