### PR TITLE
Image Corruption Toolbox: make user defined parameter with empty list to use default values

### DIFF
--- a/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/blur_corruptions/aiverify_blur_corruptions/algo.py
+++ b/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/blur_corruptions/aiverify_blur_corruptions/algo.py
@@ -290,7 +290,7 @@ class Plugin(IAlgorithm):
 
         # Apply user defined parameters to default parameters
         corruption_fn = {name: blur.CORRUPTION_FN[name] for name in self._input_arguments["corruptions"]}
-        user_params = {k: v for k, v in self._input_arguments.items() if k in blur.DEFAULT_PARAMS and v is not None}
+        user_params = {k: v for k, v in self._input_arguments.items() if k in blur.DEFAULT_PARAMS and v}
         parameters = copy.deepcopy(blur.DEFAULT_PARAMS)
         parameters.update(user_params)
 

--- a/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/digital_corruptions/aiverify_digital_corruptions/algo.py
+++ b/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/digital_corruptions/aiverify_digital_corruptions/algo.py
@@ -290,7 +290,7 @@ class Plugin(IAlgorithm):
 
         # Apply user defined parameters to default parameters
         corruption_fn = {name: digital.CORRUPTION_FN[name] for name in self._input_arguments["corruptions"]}
-        user_params = {k: v for k, v in self._input_arguments.items() if k in digital.DEFAULT_PARAMS and v is not None}
+        user_params = {k: v for k, v in self._input_arguments.items() if k in digital.DEFAULT_PARAMS and v}
         parameters = copy.deepcopy(digital.DEFAULT_PARAMS)
         parameters.update(user_params)
 

--- a/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/environment_corruptions/aiverify_environment_corruptions/algo.py
+++ b/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/environment_corruptions/aiverify_environment_corruptions/algo.py
@@ -290,9 +290,7 @@ class Plugin(IAlgorithm):
 
         # Apply user defined parameters to default parameters
         corruption_fn = {name: environment.CORRUPTION_FN[name] for name in self._input_arguments["corruptions"]}
-        user_params = {
-            k: v for k, v in self._input_arguments.items() if k in environment.DEFAULT_PARAMS and v is not None
-        }
+        user_params = {k: v for k, v in self._input_arguments.items() if k in environment.DEFAULT_PARAMS and v}
         parameters = copy.deepcopy(environment.DEFAULT_PARAMS)
         parameters.update(user_params)
 

--- a/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/general_corruptions/aiverify_general_corruptions/algo.py
+++ b/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/general_corruptions/aiverify_general_corruptions/algo.py
@@ -290,7 +290,7 @@ class Plugin(IAlgorithm):
 
         # Apply user defined parameters to default parameters
         corruption_fn = {name: general.CORRUPTION_FN[name] for name in self._input_arguments["corruptions"]}
-        user_params = {k: v for k, v in self._input_arguments.items() if k in general.DEFAULT_PARAMS and v is not None}
+        user_params = {k: v for k, v in self._input_arguments.items() if k in general.DEFAULT_PARAMS and v}
         parameters = copy.deepcopy(general.DEFAULT_PARAMS)
         parameters.update(user_params)
 


### PR DESCRIPTION
## Description

When user pass empty list `[]` as Image Corruption Toolbox parameter, use default values instead of no-op.

## Motivation and Context

Previously, passing an empty list `[]` to iterable parameters in the Image Corruption Toolbox (e.g., `corruptions=[]` or `gaussian_blur_sigma=[]`) resulted in no tests being executed for that parameter. This behavior contradicted user expectations, as they often intended for empty values to trigger the parameter's default configuration instead of being ignored entirely.

This PR updates parameter handling to align with user intuition where empty list `[]` now default to the parameter's default values.

## Type of Change

<!-- Select the appropriate type of change: -->
<!-- - feat: A new feature -->
- fix: A bug fix
<!-- - chore: Routine tasks, maintenance, or tooling changes -->
<!-- - docs: Documentation updates -->
<!-- - style: Code style changes (e.g., formatting, indentation) -->
<!-- - refactor: Code refactoring without changes in functionality -->
<!-- - test: Adding or modifying tests -->
<!-- - perf: Performance improvements -->
<!-- - ci: Changes to the CI/CD configuration or scripts -->
<!-- - other: Other changes that don't fit into the above categories -->

## How to Test

@dsta-siminong has verified that this PR works on `aiverify-portal` and `aiverify-apigw`.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [x]  I have added or updated the necessary documentation (README, API docs, etc.).
- [x]  I have added appropriate unit tests or functional tests for the changes made.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [x]  I have squashed or reorganized my commits into logical units.
- [x]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
