### PR TITLE
Fix issues where input.schema.json field with selectDatabase does not allow selection of database in portal.

### DIFF
--- a/aiverify-portal/README.md
+++ b/aiverify-portal/README.md
@@ -42,6 +42,7 @@ npm link ../aiverify-shared-library
 ## Environment Variables Configuration
 
 # Link shared library
+
 cd aiverify-apigw-node
 npm link aiverify-shared-library
 
@@ -53,6 +54,7 @@ Below is a table of the environment variables and their descriptions:
 | ------------------------ | ----------------------------------------------------------------- |
 | `APIGW_HOST`             | The host address of the AI Verify API Gateway.                    |
 | `NEXT_PUBLIC_APIGW_HOST` | The public host address for the API Gateway used by the frontend. |
+| `PROXY_TIMEOUT`          | Set the proxy timeout. Default to 600000ms                        |
 
 ## Running the Portal
 

--- a/aiverify-portal/next.config.mjs
+++ b/aiverify-portal/next.config.mjs
@@ -138,6 +138,9 @@ const nextConfig = {
       },
     ];
   },
+  experimental: {
+    proxyTimeout: parseInt(process.env.PROXY_TIMEOUT || '60000'),
+  },
 };
 
 export default nextConfig;

--- a/aiverify-test-engine-worker/src/aiverify_test_engine_worker/pipeline/download/apigw_download.py
+++ b/aiverify-test-engine-worker/src/aiverify_test_engine_worker/pipeline/download/apigw_download.py
@@ -114,6 +114,15 @@ class ApigwDownload(Pipe):
         if task_data.task.groundTruthDataset:
             task_data.ground_truth_path = self._download_dataset(
                 task_data.task.groundTruthDataset, task_data.task.groundTruthDatasetHash)
+            
+        # check if any of the algo arguments require dataset download
+        if task_data.task.algorithmArgs:
+            for key in task_data.task.algorithmArgs.keys():
+                value = task_data.task.algorithmArgs[key]
+                if isinstance(value, str) and value.startswith("_dataset_:"):
+                    ds = value[len("_dataset_:"):]
+                    p = self._download_dataset(ds, None)
+                    task_data.task.algorithmArgs[key] = p.absolute().as_posix()
 
         # data.intermediate_data[self.pipe_stage] = {
         #     "hello": "world"

--- a/stock-plugins/aiverify.stock.fairness-metrics-toolbox-for-classification/algorithms/fairness_metrics_toolbox_for_classification/README.md
+++ b/stock-plugins/aiverify.stock.fairness-metrics-toolbox-for-classification/algorithms/fairness_metrics_toolbox_for_classification/README.md
@@ -29,12 +29,11 @@ Run the below bash script to execute the plugin
 
 root_path="<PATH_TO_FOLDER>/aiverify/stock-plugins/user_defined_files"
 python -m aiverify_fairness_metrics_toolbox_for_classification \
-  --data_path $root_path/data/sample_mc_pipeline_toxic_data.sav \
-  --model_path $root_path/pipeline/mc_tabular_toxic \
-  --ground_truth_path $root_path/data/sample_mc_pipeline_toxic_ytest_data.sav \
+  --data_path $root_path/data/sample_mc_toxic_data.sav \
+  --model_path $root_path/model/sample_mc_toxic_sklearn_linear.LogisticRegression.sav \
+  --ground_truth_path $root_path/data/sample_mc_toxic_data.sav \
   --ground_truth toxic \
   --model_type CLASSIFICATION \
-  --run_pipeline \
   --sensitive_features_list gender
 ```
 
@@ -93,11 +92,10 @@ docker run \
   -v $(pwd)/stock-plugins/aiverify.stock.fairness-metrics-toolbox-for-classification/algorithms/fairness_metrics_toolbox_for_classification/output:/app/aiverify/output \
   aiverify-fairness-metrics-toolbox-for-classification \
   --data_path /input/data/sample_mc_pipeline_toxic_data.sav \
-  --model_path /input/pipeline/mc_tabular_toxic \
+  --model_path /model/sample_mc_toxic_sklearn_linear.LogisticRegression.sav \
   --ground_truth_path /input/data/sample_mc_pipeline_toxic_ytest_data.sav \
   --ground_truth toxic \
   --model_type CLASSIFICATION \
-  --run_pipeline \
   --sensitive_features_list gender
 ```
 

--- a/stock-plugins/aiverify.stock.fairness-metrics-toolbox-for-classification/algorithms/fairness_metrics_toolbox_for_classification/aiverify_fairness_metrics_toolbox_for_classification/input.schema.json
+++ b/stock-plugins/aiverify.stock.fairness-metrics-toolbox-for-classification/algorithms/fairness_metrics_toolbox_for_classification/aiverify_fairness_metrics_toolbox_for_classification/input.schema.json
@@ -3,7 +3,7 @@
     "description": "A schema for algorithm plugin input arguments",
     "type": "object",
     "required": [
-        "sensitive_feature", "annotated_labels_path","file_name_label"
+        "sensitive_feature"
     ],
     "properties": {
         "sensitive_feature": {
@@ -19,12 +19,14 @@
             "title": "Annotated labels path",
             "description": "Annotated labels path",
             "type": "string",
+            "default": "",
             "ui:widget": "selectDataset"
         },
         "file_name_label": {
             "title": "Name of column containing image file names",
             "description": "Key in the name of the column containing the file names in the annotated ground truth dataset",
-            "type": "string"
+            "type": "string",
+            "default": ""
         }
     }
 }

--- a/stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox/aiverify_robustness_toolbox/input.schema.json
+++ b/stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox/aiverify_robustness_toolbox/input.schema.json
@@ -9,12 +9,14 @@
             "title": "Annotated ground truth path",
             "description": "Annotated ground truth path",
             "type": "string",
+            "default": "",
             "ui:widget": "selectDataset"
         },
         "file_name_label": {
             "title": "Name of column containing image file names",
             "description": "Key in the name of the column containing the file names in the annotated ground truth dataset",
-            "type": "string"
+            "type": "string",
+            "default": ""
         }
     }
 }


### PR DESCRIPTION
## Description

Fix issues:
- set proxyTimeout of portal proxy to PROXY_TIMEOUT env variable or default to 60000.
- For algorithms input.schema.json, properties with "ui:widget" set to "selectDataset" will now be handled by portal. 
- Test Engine Worker download and set real path of dataset in algorithm arguments with value starting with "_dataset_:"
- update input.schema.json of fmtc and robustness toolkit.
- update README of fmtc to use non-pipeline models.

## Motivation and Context

[Explain the motivation or the context behind this pull request. Why is it necessary?]

## Type of Change

<!-- Select the appropriate type of change: -->
<!-- - feat: A new feature -->
<!-- - fix: A bug fix -->
<!-- - chore: Routine tasks, maintenance, or tooling changes -->
<!-- - docs: Documentation updates -->
<!-- - style: Code style changes (e.g., formatting, indentation) -->
<!-- - refactor: Code refactoring without changes in functionality -->
<!-- - test: Adding or modifying tests -->
<!-- - perf: Performance improvements -->
<!-- - ci: Changes to the CI/CD configuration or scripts -->
<!-- - other: Other changes that don't fit into the above categories -->

## How to Test

1. Build and install new portal and test-engine-worker.
2. Update plugin aiverify.stock.robustness-toolkit and aiverify.stock.fairness-metrics-toolbox-for-classification.
3. Navigate to http://localhost:3000/results/run
4. Select algo fairness_metrics_toolbox_for_classification. 
5. Check that `Annotated labels path` now show list of datasets.
6. Fill in test parameters and use non-pipeline model
7. Run test and make sure test result success

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [x]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
