### PR TITLE
Workflow to build and publish to PyPI

### DIFF
--- a/.github/workflows/v2-publish-pypi.yml
+++ b/.github/workflows/v2-publish-pypi.yml
@@ -19,6 +19,10 @@ on:
         description: 'Set to true to publish the test engine instead of plugins (mutually exclusive)'
         required: false
         default: 'false'
+      branch:
+        description: 'Branch to checkout (optional; defaults to main)'
+        required: false
+        default: 'main'
 
   push:
     branches:
@@ -29,7 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}      
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/v2-publish-pypi.yml
+++ b/.github/workflows/v2-publish-pypi.yml
@@ -20,6 +20,10 @@ on:
         required: false
         default: 'false'
 
+  push:
+    branches:
+      - ci/publish-pypi
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/v2-publish-pypi.yml
+++ b/.github/workflows/v2-publish-pypi.yml
@@ -1,0 +1,70 @@
+name: Build and Publish PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Where to publish (test-pypi, pypi, or leave empty for none)'
+        required: false
+        default: ''
+      plugin:
+        description: 'Plugin name (optional; if not provided, all plugins will be built)'
+        required: false
+        default: ''
+      algo:
+        description: 'Algorithm name (optional; if not provided, all algorithms will be built)'
+        required: false
+        default: ''
+      test_engine:
+        description: 'Set to true to publish the test engine instead of plugins (mutually exclusive)'
+        required: false
+        default: 'false'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Hatch
+        run: pip install hatch
+
+      # This step builds and publishes the plugin(s) based on the provided input parameters.
+      - name: Build and publish plugin
+        if: ${{ github.event.inputs.test_engine != 'true' }}
+        env:
+          TEST_PYPI_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          args=""
+          if [ "${{ github.event.inputs.publish }}" != "" ]; then
+            args="$args --publish ${{ github.event.inputs.publish }}"
+          fi
+          if [ "${{ github.event.inputs.plugin }}" != "" ]; then
+            args="$args --plugin ${{ github.event.inputs.plugin }}"
+          fi
+          if [ "${{ github.event.inputs.algo }}" != "" ]; then
+            args="$args --algo ${{ github.event.inputs.algo }}"
+          fi
+          echo "Running: ./ci/publish-pypi-plugin.sh $args"
+          bash .ci/publish-pypi-plugin.sh $args
+
+      # This step builds and publishes the test engine if the test_engine input is set to true.
+      - name: Build and publish test engine
+        if: ${{ github.event.inputs.test_engine == 'true' }}
+        env:
+          TEST_PYPI_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          args=""
+          if [ "${{ github.event.inputs.publish }}" != "" ]; then
+            args="--publish ${{ github.event.inputs.publish }}"
+          fi
+          echo "Running: ./ci/publish-pypi-test-engine.sh $args"
+          bash .ci/publish-pypi-test-engine.sh $args

--- a/.github/workflows/v2-pypi-build-publish.yml
+++ b/.github/workflows/v2-pypi-build-publish.yml
@@ -75,10 +75,6 @@ on:
         required: false
         default: 'main'
 
-  push:
-    branches:
-      - ci/publish-pypi
-
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/v2-pypi-build-publish.yml
+++ b/.github/workflows/v2-pypi-build-publish.yml
@@ -1,4 +1,55 @@
-name: Build and Publish PyPI
+# -----------------------------------------------------------------------------
+# Workflow: PyPI Build and Publish
+#
+# Overview:
+# This GitHub Actions workflow builds and publishes Python packages (plugins or
+# the test engine) to PyPI or Test PyPI. It can be triggered manually via the 
+# 'workflow_dispatch' event.
+#
+# Inputs:
+# - publish:
+#     Description: Where to publish ('test-pypi', 'pypi', or leave empty for dry run)
+#     Default: ''
+#
+# - plugin:
+#     Description: Plugin name (optional; builds all plugins if not specified)
+#     Default: ''
+#
+# - algo:
+#     Description: Algorithm name (optional; builds all algorithms if not specified)
+#     Default: ''
+#
+# - test_engine:
+#     Description: Set to 'true' to publish the test engine instead of plugins
+#     Default: 'false'
+#
+# - branch:
+#     Description: Branch to checkout (defaults to 'main' if not specified)
+#     Default: 'main'
+#
+# Jobs:
+# - build-and-publish:
+#     Runs on: ubuntu-latest
+#     Steps:
+#     1. Checkout repository using the specified branch.
+#     2. Set up Python (v3.11) environment.
+#     3. Install Hatch (Python build tool).
+#     4. Build and publish plugin(s) if 'test_engine' is false:
+#        - Runs './ci/publish-pypi-plugin.sh' with dynamically built arguments.
+#     5. Build and publish test engine if 'test_engine' is true:
+#        - Runs './ci/publish-pypi-test-engine.sh' with dynamically built arguments.
+#
+# Secrets:
+# - TEST_PYPI_TOKEN: Token for authenticating with Test PyPI.
+# - PYPI_TOKEN: Token for authenticating with PyPI.
+#
+# Notes:
+# - The workflow supports flexible configuration via manual dispatch inputs.
+# - Default behavior (if no inputs are provided) is to build all plugins on the 
+#   'main' branch without publishing (dry run).
+# -----------------------------------------------------------------------------
+
+name: PyPI Build and Publish
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Description

Workflow to build and publish to PyPI

## Motivation and Context

Can be triggered from Actions tab instead of running the script locally.

## Type of Change

- ci: Changes to the CI/CD configuration or scripts 

## How to Test

Run the workflow using the gh CLI, e.g.:
gh workflow run 'PyPI Build and Publish' --ref ci/publish-pypi -f branch=ci/publish-pypi -f publish=test-pypi

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
