### PR TITLE
Fix portal proxy rewrite issue

### DIFF
--- a/aiverify-apigw/aiverify-apigw-node/package-lock.json
+++ b/aiverify-apigw/aiverify-apigw-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiverify-apigw-node",
-  "version": "2.0.0a1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiverify-apigw-node",
-      "version": "2.0.0a1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.24.0",

--- a/aiverify-portal/Dockerfile
+++ b/aiverify-portal/Dockerfile
@@ -2,7 +2,6 @@ FROM node:23-alpine AS base
 RUN apk update && apk upgrade
 ARG TARGETARCH
 
-ARG NEXT_PUBLIC_APIGW_HOST=http://127.0.0.1:4000
 ARG APIGW_HOST=http://host.docker.internal:4000
 
 WORKDIR /app
@@ -21,7 +20,6 @@ RUN npm run build
 # RUN npm run build
 
 # ENV NODE_ENV=production
-ENV NEXT_PUBLIC_APIGW_HOST=$NEXT_PUBLIC_APIGW_HOST
 ENV APIGW_HOST=$APIGW_HOST
 EXPOSE 3000
 

--- a/aiverify-portal/README.md
+++ b/aiverify-portal/README.md
@@ -50,11 +50,10 @@ The AI Verify Portal requires certain environment variables to be configured for
 
 Below is a table of the environment variables and their descriptions:
 
-| Variable Name            | Description                                                       |
-| ------------------------ | ----------------------------------------------------------------- |
-| `APIGW_HOST`             | The host address of the AI Verify API Gateway.                    |
-| `NEXT_PUBLIC_APIGW_HOST` | The public host address for the API Gateway used by the frontend. |
-| `PROXY_TIMEOUT`          | Set the proxy timeout. Default to 600000ms                        |
+| Variable Name   | Description                                    |
+| --------------- | ---------------------------------------------- |
+| `APIGW_HOST`    | The host address of the AI Verify API Gateway. |
+| `PROXY_TIMEOUT` | Set the proxy timeout. Default to 600000ms     |
 
 ## Running the Portal
 

--- a/aiverify-portal/app/api/[[...slug]]/route.ts
+++ b/aiverify-portal/app/api/[[...slug]]/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server';
+
+// Define APIGW_HOST at the top of the file
+const APIGW_HOST = process.env.APIGW_HOST || 'http://127.0.0.1:4000';
+// console.log('APIGW_HOST', APIGW_HOST);
+
+async function _backendFetch(
+  request: Request,
+  method: string,
+  slug?: string[] | undefined
+) {
+  const path = slug ? slug.join('/') : '';
+  const url = new URL(request.url);
+  const searchParam = new URLSearchParams(url.search);
+  const backendUrl = new URL(
+    path + (searchParam.size > 0 ? '?' + searchParam.toString() : ''),
+    APIGW_HOST
+  );
+  console.log('backendUrl:', backendUrl);
+
+  const response = await fetch(backendUrl, {
+    method: method,
+    headers: request.headers,
+    body: request.body,
+    // @ts-ignore
+    duplex: 'half',
+  });
+
+  return new NextResponse(response.body, {
+    status: response.status,
+    headers: response.headers,
+  });
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ slug: string[] }> }
+) {
+  const { slug } = await params;
+  return _backendFetch(request, 'GET', slug);
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ slug: string[] }> }
+) {
+  const { slug } = await params;
+  return _backendFetch(request, 'POST', slug);
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ slug: string[] }> }
+) {
+  const { slug } = await params;
+  return _backendFetch(request, 'PUT', slug);
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ slug: string[] }> }
+) {
+  const { slug } = await params;
+  return _backendFetch(request, 'PATCH', slug);
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ slug: string[] }> }
+) {
+  const { slug } = await params;
+  return _backendFetch(request, 'DELETE', slug);
+}

--- a/aiverify-portal/app/api/[[...slug]]/route.ts
+++ b/aiverify-portal/app/api/[[...slug]]/route.ts
@@ -9,27 +9,59 @@ async function _backendFetch(
   method: string,
   slug?: string[] | undefined
 ) {
+  // console.log('request:', request);
   const path = slug ? slug.join('/') : '';
   const url = new URL(request.url);
+  // console.log('path:', path);
+  // console.log('url:', url);
   const searchParam = new URLSearchParams(url.search);
-  const backendUrl = new URL(
-    path + (searchParam.size > 0 ? '?' + searchParam.toString() : ''),
-    APIGW_HOST
-  );
-  console.log('backendUrl:', backendUrl);
+  let mypath =
+    path + (searchParam.size > 0 ? '?' + searchParam.toString() : '');
+  if (request.url.endsWith('/') && !mypath.endsWith('/')) {
+    mypath += '/';
+  }
+  const backendUrl = new URL(mypath, APIGW_HOST);
+  // console.log('backendUrl:', backendUrl);
 
-  const response = await fetch(backendUrl, {
-    method: method,
-    headers: request.headers,
-    body: request.body,
-    // @ts-ignore
-    duplex: 'half',
-  });
+  try {
+    const body = ['GET', 'HEAD'].includes(request.method)
+      ? null
+      : await request.blob();
+    // console.log('body:', body);
+    let response = await fetch(backendUrl, {
+      method: method,
+      headers: request.headers,
+      body,
+      // @ts-ignore
+      // duplex: 'half',
+      redirect: 'manual',
+    });
+    // console.log('response:', response);
 
-  return new NextResponse(response.body, {
-    status: response.status,
-    headers: response.headers,
-  });
+    if (response.status === 307 && response.headers.has('location')) {
+      response = await fetch(
+        response.headers.get('location') || backendUrl + '/',
+        {
+          method: method,
+          headers: request.headers,
+          body,
+        }
+      );
+      // console.log('response 2:', response);
+    }
+
+    return new NextResponse(response.body, {
+      status: response.status,
+      headers: response.headers,
+    });
+  } catch (e: unknown) {
+    console.log('apigw fetch error: ', e);
+    if (e instanceof Error) {
+      return new NextResponse(e.message, { status: 500 });
+    } else {
+      return new NextResponse('Unknown error', { status: 500 });
+    }
+  }
 }
 
 export async function GET(

--- a/aiverify-portal/app/canvas/components/gridItemComponent.tsx
+++ b/aiverify-portal/app/canvas/components/gridItemComponent.tsx
@@ -110,10 +110,10 @@ type GridItemComponentProps = {
   hasVisitedDataSelection: boolean;
 
   useRealData: boolean; // whether to use real or mock data
-  
+
   /** Number of tests/algorithms required for the report */
   requiredTestCount: number;
-  
+
   /** Number of tests/algorithms that have been selected */
   selectedTestCount: number;
 };
@@ -366,7 +366,7 @@ function GridItemMain({
           if (testResult && testResult.artifacts) {
             const artifactUrls = testResult.artifacts.map(
               (artifactPath) =>
-                `${process.env.NEXT_PUBLIC_APIGW_HOST}/test_results/${result.testResultId}/artifacts/${artifactPath}`
+                `/api/test_results/${result.testResultId}/artifacts/${artifactPath}`
             );
             acc[`${gid}:${result.cid}`] = artifactUrls;
           } else if (!useRealData) {
@@ -756,7 +756,7 @@ function GridItemMain({
 export const GridItemComponent = React.memo(
   GridItemMain,
   (prevProps, nextProps) => {
-    console.log("model", prevProps.model, nextProps.model);
+    console.log('model', prevProps.model, nextProps.model);
     // Only re-render if widget data changed, it's being dragged/resized, or selection state changed
     return (
       prevProps.widget === nextProps.widget &&

--- a/aiverify-portal/app/inputs/[gid]/[cid]/hooks/useSubmitFairnessTree.tsx
+++ b/aiverify-portal/app/inputs/[gid]/[cid]/hooks/useSubmitFairnessTree.tsx
@@ -12,7 +12,7 @@ export const useSubmitFairnessTree = () => {
   const mutation = useMutation({
     mutationFn: async (fairnessTreeData: FairnessTreeData) => {
       console.log('submit:', fairnessTreeData);
-      const response = await fetch('/api/input_block_data', {
+      const response = await fetch('/api/input_block_data/', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/aiverify-portal/app/inputs/context/InputBlockGroupDataContext.tsx
+++ b/aiverify-portal/app/inputs/context/InputBlockGroupDataContext.tsx
@@ -276,7 +276,7 @@ export const InputBlockGroupDataProvider: React.FC<{
   };
 
   const saveNewGroupData = async () => {
-    const res = await fetch(`/api/input_block_data/groups/`, {
+    const res = await fetch(`/api/input_block_data/groups`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/aiverify-portal/app/inputs/groups/[gid]/[group]/upload/page.tsx
+++ b/aiverify-portal/app/inputs/groups/[gid]/[group]/upload/page.tsx
@@ -27,7 +27,7 @@ const UploadPage = () => {
     if (activeCard) {
       if (activeCard === 'manual') {
         startTransition(async () => {
-          const response = await fetch('/api/input_block_data/groups/', {
+          const response = await fetch('/api/input_block_data/groups', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',

--- a/aiverify-portal/app/inputs/hooks/useSubmitInputBlockData.ts
+++ b/aiverify-portal/app/inputs/hooks/useSubmitInputBlockData.ts
@@ -9,8 +9,10 @@ interface InputBlockSubmission {
   data: Record<string, unknown>;
 }
 
-const submitInputBlockData = async (data: InputBlockSubmission): Promise<InputBlockData> => {
-  const response = await fetch('/api/input_block_data', {
+const submitInputBlockData = async (
+  data: InputBlockSubmission
+): Promise<InputBlockData> => {
+  const response = await fetch('/api/input_block_data/', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -42,4 +44,4 @@ export function useSubmitInputBlockData() {
     isSubmitting: mutation.isPending,
     error: mutation.error,
   };
-} 
+}

--- a/aiverify-portal/app/templates/upload/components/utils/uploadJsonFile.tsx
+++ b/aiverify-portal/app/templates/upload/components/utils/uploadJsonFile.tsx
@@ -81,7 +81,7 @@ async function uploadJsonWithFetch(
     };
 
     // Send the JSON content directly
-    const response = await fetch('/api/project_templates', {
+    const response = await fetch('/api/project_templates/', {
       method: 'POST',
       headers: headers,
       body: JSON.stringify(jsonContent),

--- a/aiverify-portal/next.config.mjs
+++ b/aiverify-portal/next.config.mjs
@@ -2,6 +2,7 @@
 
 const nextConfig = {
   reactStrictMode: false,
+  skipTrailingSlashRedirect: true,
   // async rewrites() {
   //   return [
   //     {

--- a/aiverify-portal/next.config.mjs
+++ b/aiverify-portal/next.config.mjs
@@ -2,142 +2,142 @@
 
 const nextConfig = {
   reactStrictMode: false,
-  async rewrites() {
-    return [
-      {
-        source: '/api/projects/projects/:id',
-        destination: `${process.env.APIGW_HOST}/projects/projects/:id`,
-      },
-      {
-        source: '/api/test_results/upload',
-        destination: `${process.env.APIGW_HOST}/test_results/upload`,
-      },
-      {
-        source: '/api/test_results/upload_zip',
-        destination: `${process.env.APIGW_HOST}/test_results/upload_zip`,
-      },
-      {
-        source: '/api/plugins/:pluginId/bundle/:widgetId',
-        destination: `${process.env.APIGW_HOST}/plugins/:pluginId/bundle/:widgetId`,
-      },
-      {
-        source: '/api/test_datasets',
-        destination: `${process.env.APIGW_HOST}/test_datasets`,
-      },
-      {
-        source: '/api/test_datasets/upload',
-        destination: `${process.env.APIGW_HOST}/test_datasets/upload`,
-      },
-      {
-        source: '/api/test_datasets/upload_folder',
-        destination: `${process.env.APIGW_HOST}/test_datasets/upload_folder`,
-      },
-      {
-        source: '/api/plugins/upload',
-        destination: `${process.env.APIGW_HOST}/plugins/upload`,
-      },
-      {
-        source: '/api/plugins/:id',
-        destination: `${process.env.APIGW_HOST}/plugins/:id`,
-      },
-      {
-        source: '/api/plugins/:gid/bundle/:cid',
-        destination: `${process.env.APIGW_HOST}/plugins/:gid/bundle/:cid`,
-      },
-      {
-        source: '/api/plugins/:gid/summary/:cid',
-        destination: `${process.env.APIGW_HOST}/plugins/:gid/summary/:cid`,
-      },
-      {
-        source: '/api/plugins/:gid/input_blocks',
-        destination: `${process.env.APIGW_HOST}/plugins/:gid/input_blocks`,
-      },
-      {
-        source: '/api/input_block_data/:id',
-        destination: `${process.env.APIGW_HOST}/input_block_data/:id`,
-      },
-      {
-        source: '/api/input_block_data/groups/:id',
-        destination: `${process.env.APIGW_HOST}/input_block_data/groups/:id`,
-      },
-      {
-        source: '/api/input_block_data',
-        destination: `${process.env.APIGW_HOST}/input_block_data/`,
-      },
-      {
-        source: '/api/input_block_data/groups',
-        destination: `${process.env.APIGW_HOST}/input_block_data/groups/`,
-      },
-      {
-        source: '/api/input_block_data/groups/:gid/:group',
-        destination: `${process.env.APIGW_HOST}/input_block_data/groups/:gid/:group`,
-      },
-      {
-        source: '/api/test_models/:id',
-        destination: `${process.env.APIGW_HOST}/test_models/:id`,
-      },
-      {
-        source: '/api/project_templates/:id',
-        destination: `${process.env.APIGW_HOST}/project_templates/:id`,
-      },
-      {
-        source: '/api/test_models/exportModelAPI/:id',
-        destination: `${process.env.APIGW_HOST}/test_models/exportModelAPI/:id`,
-      },
-      {
-        source: '/api/test_models/download/:id',
-        destination: `${process.env.APIGW_HOST}/test_models/download/:id`,
-      },
-      {
-        source: '/api/test_models/upload',
-        destination: `${process.env.APIGW_HOST}/test_models/upload`,
-      },
-      {
-        source: '/api/test_models/upload_folder',
-        destination: `${process.env.APIGW_HOST}/test_models/upload_folder`,
-      },
-      {
-        source: '/api/test_models/modelapi',
-        destination: `${process.env.APIGW_HOST}/test_models/modelapi`,
-      },
-      {
-        source: '/api/project_templates',
-        destination: `${process.env.APIGW_HOST}/project_templates/`,
-      },
-      {
-        source: '/api/project_templates/:id',
-        destination: `${process.env.APIGW_HOST}/project_templates/:id`,
-      },
-      {
-        source: '/api/projects/saveProjectAsTemplate/:id',
-        destination: `${process.env.APIGW_HOST}/projects/saveProjectAsTemplate/:id`,
-      },
-      {
-        source: '/api/project_templates/export/:id',
-        destination: `${process.env.APIGW_HOST}/project_templates/export/:id`,
-      },
-      {
-        source: '/api/project_templates/clone/:id',
-        destination: `${process.env.APIGW_HOST}/project_templates/clone/:id`,
-      },
-      {
-        source: '/api/test_runs/run_test',
-        destination: `${process.env.APIGW_HOST}/test_runs/run_test/`,
-      },
-      {
-        source: '/api/test_runs',
-        destination: `${process.env.APIGW_HOST}/test_runs/`,
-      },
-      {
-        source: '/api/test_runs/:id',
-        destination: `${process.env.APIGW_HOST}/test_runs/:id`,
-      },
-      {
-        source: '/api/test_runs/:id/cancel',
-        destination: `${process.env.APIGW_HOST}/test_runs/:id/cancel`,
-      },
-    ];
-  },
+  // async rewrites() {
+  //   return [
+  //     {
+  //       source: '/api/projects/projects/:id',
+  //       destination: `${process.env.APIGW_HOST}/projects/projects/:id`,
+  //     },
+  //     {
+  //       source: '/api/test_results/upload',
+  //       destination: `${process.env.APIGW_HOST}/test_results/upload`,
+  //     },
+  //     {
+  //       source: '/api/test_results/upload_zip',
+  //       destination: `${process.env.APIGW_HOST}/test_results/upload_zip`,
+  //     },
+  //     {
+  //       source: '/api/plugins/:pluginId/bundle/:widgetId',
+  //       destination: `${process.env.APIGW_HOST}/plugins/:pluginId/bundle/:widgetId`,
+  //     },
+  //     {
+  //       source: '/api/test_datasets',
+  //       destination: `${process.env.APIGW_HOST}/test_datasets`,
+  //     },
+  //     {
+  //       source: '/api/test_datasets/upload',
+  //       destination: `${process.env.APIGW_HOST}/test_datasets/upload`,
+  //     },
+  //     {
+  //       source: '/api/test_datasets/upload_folder',
+  //       destination: `${process.env.APIGW_HOST}/test_datasets/upload_folder`,
+  //     },
+  //     {
+  //       source: '/api/plugins/upload',
+  //       destination: `${process.env.APIGW_HOST}/plugins/upload`,
+  //     },
+  //     {
+  //       source: '/api/plugins/:id',
+  //       destination: `${process.env.APIGW_HOST}/plugins/:id`,
+  //     },
+  //     {
+  //       source: '/api/plugins/:gid/bundle/:cid',
+  //       destination: `${process.env.APIGW_HOST}/plugins/:gid/bundle/:cid`,
+  //     },
+  //     {
+  //       source: '/api/plugins/:gid/summary/:cid',
+  //       destination: `${process.env.APIGW_HOST}/plugins/:gid/summary/:cid`,
+  //     },
+  //     {
+  //       source: '/api/plugins/:gid/input_blocks',
+  //       destination: `${process.env.APIGW_HOST}/plugins/:gid/input_blocks`,
+  //     },
+  //     {
+  //       source: '/api/input_block_data/:id',
+  //       destination: `${process.env.APIGW_HOST}/input_block_data/:id`,
+  //     },
+  //     {
+  //       source: '/api/input_block_data/groups/:id',
+  //       destination: `${process.env.APIGW_HOST}/input_block_data/groups/:id`,
+  //     },
+  //     {
+  //       source: '/api/input_block_data',
+  //       destination: `${process.env.APIGW_HOST}/input_block_data/`,
+  //     },
+  //     {
+  //       source: '/api/input_block_data/groups',
+  //       destination: `${process.env.APIGW_HOST}/input_block_data/groups/`,
+  //     },
+  //     {
+  //       source: '/api/input_block_data/groups/:gid/:group',
+  //       destination: `${process.env.APIGW_HOST}/input_block_data/groups/:gid/:group`,
+  //     },
+  //     {
+  //       source: '/api/test_models/:id',
+  //       destination: `${process.env.APIGW_HOST}/test_models/:id`,
+  //     },
+  //     {
+  //       source: '/api/project_templates/:id',
+  //       destination: `${process.env.APIGW_HOST}/project_templates/:id`,
+  //     },
+  //     {
+  //       source: '/api/test_models/exportModelAPI/:id',
+  //       destination: `${process.env.APIGW_HOST}/test_models/exportModelAPI/:id`,
+  //     },
+  //     {
+  //       source: '/api/test_models/download/:id',
+  //       destination: `${process.env.APIGW_HOST}/test_models/download/:id`,
+  //     },
+  //     {
+  //       source: '/api/test_models/upload',
+  //       destination: `${process.env.APIGW_HOST}/test_models/upload`,
+  //     },
+  //     {
+  //       source: '/api/test_models/upload_folder',
+  //       destination: `${process.env.APIGW_HOST}/test_models/upload_folder`,
+  //     },
+  //     {
+  //       source: '/api/test_models/modelapi',
+  //       destination: `${process.env.APIGW_HOST}/test_models/modelapi`,
+  //     },
+  //     {
+  //       source: '/api/project_templates',
+  //       destination: `${process.env.APIGW_HOST}/project_templates/`,
+  //     },
+  //     {
+  //       source: '/api/project_templates/:id',
+  //       destination: `${process.env.APIGW_HOST}/project_templates/:id`,
+  //     },
+  //     {
+  //       source: '/api/projects/saveProjectAsTemplate/:id',
+  //       destination: `${process.env.APIGW_HOST}/projects/saveProjectAsTemplate/:id`,
+  //     },
+  //     {
+  //       source: '/api/project_templates/export/:id',
+  //       destination: `${process.env.APIGW_HOST}/project_templates/export/:id`,
+  //     },
+  //     {
+  //       source: '/api/project_templates/clone/:id',
+  //       destination: `${process.env.APIGW_HOST}/project_templates/clone/:id`,
+  //     },
+  //     {
+  //       source: '/api/test_runs/run_test',
+  //       destination: `${process.env.APIGW_HOST}/test_runs/run_test/`,
+  //     },
+  //     {
+  //       source: '/api/test_runs',
+  //       destination: `${process.env.APIGW_HOST}/test_runs/`,
+  //     },
+  //     {
+  //       source: '/api/test_runs/:id',
+  //       destination: `${process.env.APIGW_HOST}/test_runs/:id`,
+  //     },
+  //     {
+  //       source: '/api/test_runs/:id/cancel',
+  //       destination: `${process.env.APIGW_HOST}/test_runs/:id/cancel`,
+  //     },
+  //   ];
+  // },
   experimental: {
     proxyTimeout: parseInt(process.env.PROXY_TIMEOUT || '60000'),
   },

--- a/aiverify-portal/package-lock.json
+++ b/aiverify-portal/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiverify-portal",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiverify-portal",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dependencies": {
         "@fontsource-variable/inter": "^5.1.0",
         "@fontsource/roboto": "^5.1.0",

--- a/aiverify-portal/package.json
+++ b/aiverify-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiverify-portal",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/deployment/docker-compose-dev/compose.yaml
+++ b/deployment/docker-compose-dev/compose.yaml
@@ -41,8 +41,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      APIGW_HOST: "http://host.docker.internal:4000"
-      NEXT_PUBLIC_APIGW_HOST: "http://127.0.0.1:4000"
+      APIGW_HOST: "http://apigw:4000"
     networks:
       - aiverify_net
 

--- a/deployment/docker-compose/compose.yaml
+++ b/deployment/docker-compose/compose.yaml
@@ -35,8 +35,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      APIGW_HOST: "http://host.docker.internal:4000"
-      NEXT_PUBLIC_APIGW_HOST: "http://127.0.0.1:4000"
+      APIGW_HOST: "http://apigw:4000"
     networks:
       - aiverify_net
 

--- a/deployment/kubernetes/portal.yaml
+++ b/deployment/kubernetes/portal.yaml
@@ -46,5 +46,3 @@ spec:
           env:
             - name: APIGW_HOST
               value: "http://apigw.aiverify.svc.cluster.local:4000"
-            - name: NEXT_PUBLIC_APIGW_HOST
-              value: "http://127.0.0.1:4000"


### PR DESCRIPTION
## Description

Changes:

- For portal, change the nextJS rewrite to proxy using route app "/api"
- Remove use of env variable `NEXT_PUBLIC_APIGW_HOST`, as all api request now proxied using "/api" route.
- Fix wrong env value `APIGW_HOST` in the docker compose deployment files, use value "http://apigw:4000" instead of "http://apigw:4000"

## Motivation and Context

Previous using `APIGW_HOST` environment variable in the portal's next.config.mjs cause the env value to in inlined during portal build and run. This causes the docker build to be unusable in different environments where the `APIGW_HOST` need to be changed. 

Fix issue: https://github.com/aiverify-foundation/aiverify/issues/551.

## Type of Change

<!-- Select the appropriate type of change: -->
<!-- - feat: A new feature -->
<!-- - fix: A bug fix -->
<!-- - chore: Routine tasks, maintenance, or tooling changes -->
<!-- - docs: Documentation updates -->
<!-- - style: Code style changes (e.g., formatting, indentation) -->
<!-- - refactor: Code refactoring without changes in functionality -->
<!-- - test: Adding or modifying tests -->
<!-- - perf: Performance improvements -->
<!-- - ci: Changes to the CI/CD configuration or scripts -->
<!-- - other: Other changes that don't fit into the above categories -->
fix

## How to Test

1. Use the `compose.yaml` file under `deployment/docker-compose-dev` to build and run AI Verify services. 
```
COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose --profile automated-tests-venv --profile portal build --no-cache
```

2. Make sure all services are running and access the portal on http://localhost:3000/.
3. Test all the portal pages and functionaries to make sure all backend communications are working.

Repeat test steps 2-3 but deploy on K8s instead. 

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [x]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
