### PR TITLE
Do not run the run-image-build-push job if matrix is emtpy

### DIFF
--- a/.github/workflows/v2-docker-build-push.yml
+++ b/.github/workflows/v2-docker-build-push.yml
@@ -35,7 +35,7 @@ on:
 
   # When there are changes to pyproject.toml, package.json
   push:
-    branches: [ main, ci/release-docker-image-fix ]
+    branches: [ main ]
     paths:
       - '**/pyproject.toml'
       - '**/package.json'

--- a/.github/workflows/v2-docker-build-push.yml
+++ b/.github/workflows/v2-docker-build-push.yml
@@ -155,7 +155,10 @@ jobs:
           echo "pr_num=${{ env.PR_NUM }}" >> $GITHUB_OUTPUT
           echo "image_tag=${{ env.IMAGE_TAG }}" >> $GITHUB_OUTPUT
           echo "matrix={\"include\":$matrix_include}" >> $GITHUB_OUTPUT
-
+          if [ -z "$matrix_include" ]; then
+            echo "Nothing to build"
+          fi
+          
   # Job to run the actual image build and push, if matrix is not empty
   run-image-build-push:
     needs: init-image-build-push

--- a/.github/workflows/v2-docker-build-push.yml
+++ b/.github/workflows/v2-docker-build-push.yml
@@ -35,7 +35,7 @@ on:
 
   # When there are changes to pyproject.toml, package.json
   push:
-    branches: [ main ]
+    branches: [ main, ci/release-docker-image-fix ]
     paths:
       - '**/pyproject.toml'
       - '**/package.json'

--- a/.github/workflows/v2-docker-build-push.yml
+++ b/.github/workflows/v2-docker-build-push.yml
@@ -159,7 +159,7 @@ jobs:
   # Job to run the actual image build and push, if matrix is not empty
   run-image-build-push:
     needs: init-image-build-push
-    if: ${{ fromJson(needs.init-image-build-push.outputs.matrix).include != '' }}
+    if: ${{ needs.init-image-build-push.outputs.matrix != '{"include":[]}' }}
     runs-on: ubuntu-latest
     timeout-minutes: 360
     strategy:

--- a/.github/workflows/v2-docker-build-push.yml
+++ b/.github/workflows/v2-docker-build-push.yml
@@ -155,7 +155,7 @@ jobs:
           echo "pr_num=${{ env.PR_NUM }}" >> $GITHUB_OUTPUT
           echo "image_tag=${{ env.IMAGE_TAG }}" >> $GITHUB_OUTPUT
           echo "matrix={\"include\":$matrix_include}" >> $GITHUB_OUTPUT
-          if [ matrix == '{"include":[]}' ]; then
+          if [ $MATRIX == '{"include":[]}' ]; then
             echo "Nothing to build"
           fi
 

--- a/.github/workflows/v2-docker-build-push.yml
+++ b/.github/workflows/v2-docker-build-push.yml
@@ -1,8 +1,8 @@
 # GitHub Actions Workflow: v2 Docker Build and Push
 # 
 # This workflow builds and pushes Docker images to GitHub Container Registry (ghcr)
-# for selected components of the aiverify project. It can be triggered manually,
-# or when a version change is detected in pyproject.toml or package.json. For
+# for apigw, portal and test-engine-worker. It can be triggered manually, or
+# when a version change is detected in pyproject.toml or package.json. For
 # aiverify-test-engine-worker, it builds multiple targets (base, venv, docker).
 
 name: v2 Docker Build and Push
@@ -33,6 +33,7 @@ on:
         description: 'Tag for the image, e.g. 2.0.2'
         required: false
 
+  # When there are changes to pyproject.toml, package.json
   push:
     branches: [ main ]
     paths:
@@ -155,9 +156,10 @@ jobs:
           echo "image_tag=${{ env.IMAGE_TAG }}" >> $GITHUB_OUTPUT
           echo "matrix={\"include\":$matrix_include}" >> $GITHUB_OUTPUT
 
-  # Job to run the actual image build and push steps
-  run-image-image-build-push:
+  # Job to run the actual image build and push, if matrix is not empty
+  run-image-build-push:
     needs: init-image-build-push
+    if: ${{ fromJson(needs.init-image-build-push.outputs.matrix).include != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 360
     strategy:

--- a/.github/workflows/v2-docker-build-push.yml
+++ b/.github/workflows/v2-docker-build-push.yml
@@ -155,10 +155,10 @@ jobs:
           echo "pr_num=${{ env.PR_NUM }}" >> $GITHUB_OUTPUT
           echo "image_tag=${{ env.IMAGE_TAG }}" >> $GITHUB_OUTPUT
           echo "matrix={\"include\":$matrix_include}" >> $GITHUB_OUTPUT
-          if [ -z "$matrix_include" ]; then
+          if [ matrix == '{"include":[]}' ]; then
             echo "Nothing to build"
           fi
-          
+
   # Job to run the actual image build and push, if matrix is not empty
   run-image-build-push:
     needs: init-image-build-push

--- a/aiverify-apigw/pyproject.toml
+++ b/aiverify-apigw/pyproject.toml
@@ -10,7 +10,7 @@ Source = "https://github.com/aiverify-foundation/aiverify/tree/v2.x"
 [project]
 name = "aiverify-apigw"
 version = "2.0.1"
-description = 'The aapigw provides middleware functionality for the aiverify portal'
+description = 'The apigw provides middleware functionality for the aiverify portal'
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"

--- a/aiverify-apigw/pyproject.toml
+++ b/aiverify-apigw/pyproject.toml
@@ -10,7 +10,7 @@ Source = "https://github.com/aiverify-foundation/aiverify/tree/v2.x"
 [project]
 name = "aiverify-apigw"
 version = "2.0.1"
-description = 'The apigw provides middleware functionality for the aiverify portal'
+description = 'The aapigw provides middleware functionality for the aiverify portal'
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"


### PR DESCRIPTION
## Description

Do not run the run-image-build-push job if matrix is emtpy

## Motivation and Context

Ensure the workflow does not appear as error if there is no image to build (e.g. when there is a change in the pyproject.toml detected, but the version is not changed)

## Type of Change
- ci: Changes to the CI/CD configuration or scripts

## How to Test

Please refer to the test workflow run https://github.com/aiverify-foundation/aiverify/actions/runs/15207789298 for the test result.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
