### PR TITLE
Fix/algo init

### DIFF
--- a/stock-plugins/aiverify.stock.accumulated-local-effect/algorithms/accumulated_local_effect/README.md
+++ b/stock-plugins/aiverify.stock.accumulated-local-effect/algorithms/accumulated_local_effect/README.md
@@ -106,5 +106,9 @@ If the algorithm runs successfully, the results of the test will be saved in an 
 Run the following steps to execute the unit and integration tests inside the `tests/` folder
 
 ```sh
-docker run --entrypoint python3 aiverify-accumulated-local-effect -m pytest .
+docker run \
+  --entrypoint python3 \
+  -w /app/aiverify/stock-plugins/aiverify.stock.accumulated-local-effect/algorithms/accumulated_local_effect \
+  aiverify-accumulated-local-effect \
+  -m pytest .
 ```

--- a/stock-plugins/aiverify.stock.accumulated-local-effect/algorithms/accumulated_local_effect/aiverify_accumulated_local_effect/algo_init.py
+++ b/stock-plugins/aiverify.stock.accumulated-local-effect/algorithms/accumulated_local_effect/aiverify_accumulated_local_effect/algo_init.py
@@ -15,6 +15,7 @@ from aiverify_test_engine.interfaces.ipipeline import IPipeline
 from aiverify_test_engine.interfaces.iserializer import ISerializer
 from aiverify_test_engine.interfaces.itestresult import ITestArguments, ITestResult
 from aiverify_test_engine.plugins.enums.model_type import ModelType
+from aiverify_test_engine.plugins.enums.pipeline_plugin_type import PipelinePluginType
 from aiverify_test_engine.plugins.enums.plugin_type import PluginType
 from aiverify_test_engine.plugins.plugins_manager import PluginManager
 from aiverify_test_engine.utils.json_utils import (
@@ -139,16 +140,17 @@ class AlgoInit:
                 # Perform a copy of the initial data and model information
                 self._initial_data_instance = copy.deepcopy(self._data_instance)
                 self._initial_model_instance = copy.deepcopy(self._model_instance)
-
-                # Perform data transformation
-                current_dataset = self._data_instance.get_data()
-                current_pipeline = self._model_instance.get_pipeline()
-                data_transformation_stages = current_pipeline[:-1]
-                transformed_dataset = data_transformation_stages.transform(current_dataset)
-                transformed_pipeline = current_pipeline[-1]
-                # Set new transformed pipeline and dataset
-                self._data_instance.set_data(transformed_dataset)
-                self._model_instance.set_pipeline(transformed_pipeline)
+                
+                if self._model_instance.get_pipeline_plugin_type() == PipelinePluginType.SKLEARN:
+                    # Perform data transformation
+                    current_dataset = self._data_instance.get_data()
+                    current_pipeline = self._model_instance.get_pipeline()
+                    data_transformation_stages = current_pipeline[:-1]
+                    transformed_dataset = data_transformation_stages.transform(current_dataset)
+                    transformed_pipeline = current_pipeline[-1]
+                    # Set new transformed pipeline and dataset
+                    self._data_instance.set_data(transformed_dataset)
+                    self._model_instance.set_pipeline(transformed_pipeline)
 
             else:
                 # Get the data, model, and ground truth instance

--- a/stock-plugins/aiverify.stock.fairness-metrics-toolbox-for-classification/algorithms/fairness_metrics_toolbox_for_classification/README.md
+++ b/stock-plugins/aiverify.stock.fairness-metrics-toolbox-for-classification/algorithms/fairness_metrics_toolbox_for_classification/README.md
@@ -108,5 +108,9 @@ If the algorithm runs successfully, the results of the test will be saved in an 
 Run the following steps to execute the unit and integration tests inside the `tests/` folder
 
 ```sh
-docker run --entrypoint python3 aiverify-fairness-metrics-toolbox-for-classification -m pytest .
+docker run \
+  --entrypoint python3 \
+  -w /app/aiverify/stock-plugins/aiverify.stock.fairness-metrics-toolbox-for-classification/algorithms/fairness_metrics_toolbox_for_classification \
+  aiverify-fairness-metrics-toolbox-for-classification \
+  -m pytest .
 ```

--- a/stock-plugins/aiverify.stock.fairness-metrics-toolbox-for-classification/algorithms/fairness_metrics_toolbox_for_classification/aiverify_fairness_metrics_toolbox_for_classification/algo_init.py
+++ b/stock-plugins/aiverify.stock.fairness-metrics-toolbox-for-classification/algorithms/fairness_metrics_toolbox_for_classification/aiverify_fairness_metrics_toolbox_for_classification/algo_init.py
@@ -15,6 +15,7 @@ from aiverify_test_engine.interfaces.ipipeline import IPipeline
 from aiverify_test_engine.interfaces.iserializer import ISerializer
 from aiverify_test_engine.interfaces.itestresult import ITestArguments, ITestResult
 from aiverify_test_engine.plugins.enums.model_type import ModelType
+from aiverify_test_engine.plugins.enums.pipeline_plugin_type import PipelinePluginType
 from aiverify_test_engine.plugins.enums.plugin_type import PluginType
 from aiverify_test_engine.plugins.plugins_manager import PluginManager
 from aiverify_test_engine.utils.json_utils import (
@@ -141,15 +142,16 @@ class AlgoInit:
                 self._initial_data_instance = copy.deepcopy(self._data_instance)
                 self._initial_model_instance = copy.deepcopy(self._model_instance)
 
-                # Perform data transformation
-                current_dataset = self._data_instance.get_data()
-                current_pipeline = self._model_instance.get_pipeline()
-                data_transformation_stages = current_pipeline[:-1]
-                transformed_dataset = data_transformation_stages.transform(current_dataset)
-                transformed_pipeline = current_pipeline[-1]
-                # Set new transformed pipeline and dataset
-                self._data_instance.set_data(transformed_dataset)
-                self._model_instance.set_pipeline(transformed_pipeline)
+                if self._model_instance.get_pipeline_plugin_type() == PipelinePluginType.SKLEARN:
+                    # Perform data transformation
+                    current_dataset = self._data_instance.get_data()
+                    current_pipeline = self._model_instance.get_pipeline()
+                    data_transformation_stages = current_pipeline[:-1]
+                    transformed_dataset = data_transformation_stages.transform(current_dataset)
+                    transformed_pipeline = current_pipeline[-1]
+                    # Set new transformed pipeline and dataset
+                    self._data_instance.set_data(transformed_dataset)
+                    self._model_instance.set_pipeline(transformed_pipeline)
 
             else:
                 # Get the data, model, and ground truth instance

--- a/stock-plugins/aiverify.stock.fairness-metrics-toolbox-for-regression/algorithms/fairness_metrics_toolbox_for_regression/README.md
+++ b/stock-plugins/aiverify.stock.fairness-metrics-toolbox-for-regression/algorithms/fairness_metrics_toolbox_for_regression/README.md
@@ -110,5 +110,9 @@ If the algorithm runs successfully, the results of the test will be saved in an 
 Run the following steps to execute the unit and integration tests inside the `tests/` folder
 
 ```sh
-docker run --entrypoint python3 aiverify-fairness-metrics-toolbox-for-regression -m pytest .
+docker run \
+  --entrypoint python3 \
+  -w /app/aiverify/stock-plugins/aiverify.stock.fairness-metrics-toolbox-for-regression/algorithms/fairness_metrics_toolbox_for_regression \
+  aiverify-fairness-metrics-toolbox-for-regression \
+  -m pytest .
 ```

--- a/stock-plugins/aiverify.stock.fairness-metrics-toolbox-for-regression/algorithms/fairness_metrics_toolbox_for_regression/aiverify_fairness_metrics_toolbox_for_regression/algo_init.py
+++ b/stock-plugins/aiverify.stock.fairness-metrics-toolbox-for-regression/algorithms/fairness_metrics_toolbox_for_regression/aiverify_fairness_metrics_toolbox_for_regression/algo_init.py
@@ -15,6 +15,7 @@ from aiverify_test_engine.interfaces.ipipeline import IPipeline
 from aiverify_test_engine.interfaces.iserializer import ISerializer
 from aiverify_test_engine.interfaces.itestresult import ITestArguments, ITestResult
 from aiverify_test_engine.plugins.enums.model_type import ModelType
+from aiverify_test_engine.plugins.enums.pipeline_plugin_type import PipelinePluginType
 from aiverify_test_engine.plugins.enums.plugin_type import PluginType
 from aiverify_test_engine.plugins.plugins_manager import PluginManager
 from aiverify_test_engine.utils.json_utils import (
@@ -140,15 +141,16 @@ class AlgoInit:
                 self._initial_data_instance = copy.deepcopy(self._data_instance)
                 self._initial_model_instance = copy.deepcopy(self._model_instance)
 
-                # Perform data transformation
-                current_dataset = self._data_instance.get_data()
-                current_pipeline = self._model_instance.get_pipeline()
-                data_transformation_stages = current_pipeline[:-1]
-                transformed_dataset = data_transformation_stages.transform(current_dataset)
-                transformed_pipeline = current_pipeline[-1]
-                # Set new transformed pipeline and dataset
-                self._data_instance.set_data(transformed_dataset)
-                self._model_instance.set_pipeline(transformed_pipeline)
+                if self._model_instance.get_pipeline_plugin_type() == PipelinePluginType.SKLEARN:
+                    # Perform data transformation
+                    current_dataset = self._data_instance.get_data()
+                    current_pipeline = self._model_instance.get_pipeline()
+                    data_transformation_stages = current_pipeline[:-1]
+                    transformed_dataset = data_transformation_stages.transform(current_dataset)
+                    transformed_pipeline = current_pipeline[-1]
+                    # Set new transformed pipeline and dataset
+                    self._data_instance.set_data(transformed_dataset)
+                    self._model_instance.set_pipeline(transformed_pipeline)
 
             else:
                 # Get the data, model, and ground truth instance

--- a/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/blur_corruptions/README.md
+++ b/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/blur_corruptions/README.md
@@ -242,5 +242,9 @@ If the algorithm runs successfully, the results of the test will be saved in an 
 Run the following steps to execute the unit and integration tests inside the `tests/` folder
 
 ```sh
-docker run --entrypoint python3 aiverify-blur-corruptions -m pytest .
+docker run \
+  --entrypoint python3 \
+  -w /app/aiverify/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/blur_corruptions \
+  aiverify-blur-corruptions \
+  -m pytest .
 ```

--- a/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/digital_corruptions/README.md
+++ b/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/digital_corruptions/README.md
@@ -244,5 +244,9 @@ If the algorithm runs successfully, the results of the test will be saved in an 
 Run the following steps to execute the unit and integration tests inside the `tests/` folder
 
 ```sh
-docker run --entrypoint python3 aiverify-digital-corruptions -m pytest .
+docker run \
+  --entrypoint python3 \
+  -w /app/aiverify/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/digital_corruptions \
+  aiverify-digital-corruptions \
+  -m pytest .
 ```

--- a/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/environment_corruptions/README.md
+++ b/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/environment_corruptions/README.md
@@ -239,5 +239,9 @@ If the algorithm runs successfully, the results of the test will be saved in an 
 Run the following steps to execute the unit and integration tests inside the `tests/` folder
 
 ```sh
-docker run --entrypoint python3 aiverify-environment-corruptions -m pytest .
+docker run \
+  --entrypoint python3 \
+  -w /app/aiverify/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/environment_corruptions \
+  aiverify-environment-corruptions \
+  -m pytest .
 ```

--- a/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/general_corruptions/README.md
+++ b/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/general_corruptions/README.md
@@ -239,5 +239,9 @@ If the algorithm runs successfully, the results of the test will be saved in an 
 Run the following steps to execute the unit and integration tests inside the `tests/` folder
 
 ```sh
-docker run --entrypoint python3 aiverify-general-corruptions -m pytest .
+docker run \
+  --entrypoint python3 \
+  -w /app/aiverify/stock-plugins/aiverify.stock.image-corruption-toolbox/algorithms/general_corruptions \
+  aiverify-general-corruptions \
+  -m pytest .
 ```

--- a/stock-plugins/aiverify.stock.partial-dependence-plot/algorithms/partial_dependence_plot/README.md
+++ b/stock-plugins/aiverify.stock.partial-dependence-plot/algorithms/partial_dependence_plot/README.md
@@ -108,5 +108,9 @@ If the algorithm runs successfully, the results of the test will be saved in an 
 Run the following steps to execute the unit and integration tests inside the `tests/` folder
 
 ```sh
-docker run --entrypoint python3 aiverify-partial-dependence-plot -m pytest .
+docker run \
+  --entrypoint python3 \
+  -w /app/aiverify/stock-plugins/aiverify.stock.partial-dependence-plot/algorithms/partial_dependence_plot \
+  aiverify-partial-dependence-plot \
+  -m pytest .
 ```

--- a/stock-plugins/aiverify.stock.partial-dependence-plot/algorithms/partial_dependence_plot/aiverify_partial_dependence_plot/algo_init.py
+++ b/stock-plugins/aiverify.stock.partial-dependence-plot/algorithms/partial_dependence_plot/aiverify_partial_dependence_plot/algo_init.py
@@ -15,6 +15,7 @@ from aiverify_test_engine.interfaces.ipipeline import IPipeline
 from aiverify_test_engine.interfaces.iserializer import ISerializer
 from aiverify_test_engine.interfaces.itestresult import ITestArguments, ITestResult
 from aiverify_test_engine.plugins.enums.model_type import ModelType
+from aiverify_test_engine.plugins.enums.pipeline_plugin_type import PipelinePluginType
 from aiverify_test_engine.plugins.enums.plugin_type import PluginType
 from aiverify_test_engine.plugins.plugins_manager import PluginManager
 from aiverify_test_engine.utils.json_utils import (
@@ -139,15 +140,16 @@ class AlgoInit:
                 self._initial_data_instance = copy.deepcopy(self._data_instance)
                 self._initial_model_instance = copy.deepcopy(self._model_instance)
 
-                # Perform data transformation
-                current_dataset = self._data_instance.get_data()
-                current_pipeline = self._model_instance.get_pipeline()
-                data_transformation_stages = current_pipeline[:-1]
-                transformed_dataset = data_transformation_stages.transform(current_dataset)
-                transformed_pipeline = current_pipeline[-1]
-                # Set new transformed pipeline and dataset
-                self._data_instance.set_data(transformed_dataset)
-                self._model_instance.set_pipeline(transformed_pipeline)
+                if self._model_instance.get_pipeline_plugin_type() == PipelinePluginType.SKLEARN:
+                    # Perform data transformation
+                    current_dataset = self._data_instance.get_data()
+                    current_pipeline = self._model_instance.get_pipeline()
+                    data_transformation_stages = current_pipeline[:-1]
+                    transformed_dataset = data_transformation_stages.transform(current_dataset)
+                    transformed_pipeline = current_pipeline[-1]
+                    # Set new transformed pipeline and dataset
+                    self._data_instance.set_data(transformed_dataset)
+                    self._model_instance.set_pipeline(transformed_pipeline)
 
             else:
                 # Get the data, model, and ground truth instance

--- a/stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox/README.md
+++ b/stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox/README.md
@@ -125,5 +125,9 @@ If the algorithm runs successfully, the results of the test will be saved in an 
 Run the following steps to execute the unit and integration tests inside the `tests/` folder
 
 ```sh
-docker run --entrypoint python3 aiverify-robustness-toolbox -m pytest .
+docker run \
+  --entrypoint python3 \
+  -w /app/aiverify/stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox \
+  aiverify-robustness-toolbox \
+  -m pytest .
 ```

--- a/stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox/aiverify_robustness_toolbox/algo.py
+++ b/stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox/aiverify_robustness_toolbox/algo.py
@@ -346,6 +346,14 @@ class Plugin(IAlgorithm):
                 self._data_labels = list(self._data_instance.read_labels().keys())
                 self._data_labels_items = self._data_instance.read_labels().items()
                 self._ordered_ground_truth = self._ground_truth_instance.get_data()
+                # Apply keep_ground_truth only if not already applied
+                if isinstance(self._ordered_ground_truth, pd.DataFrame):
+                    if (
+                        len(self._ordered_ground_truth.columns) != 1
+                        or self._ordered_ground_truth.columns[0] != self._ground_truth
+                    ):
+                        self._ground_truth_instance.keep_ground_truth(self._ground_truth)
+                        self._ordered_ground_truth = self._ground_truth_instance.get_data()
 
             # Perform boundary attack
             self._perform_boundary_attack()

--- a/stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox/aiverify_robustness_toolbox/algo_init.py
+++ b/stock-plugins/aiverify.stock.robustness-toolbox/algorithms/robustness_toolbox/aiverify_robustness_toolbox/algo_init.py
@@ -15,6 +15,7 @@ from aiverify_test_engine.interfaces.ipipeline import IPipeline
 from aiverify_test_engine.interfaces.iserializer import ISerializer
 from aiverify_test_engine.interfaces.itestresult import ITestArguments, ITestResult
 from aiverify_test_engine.plugins.enums.model_type import ModelType
+from aiverify_test_engine.plugins.enums.pipeline_plugin_type import PipelinePluginType
 from aiverify_test_engine.plugins.enums.plugin_type import PluginType
 from aiverify_test_engine.plugins.plugins_manager import PluginManager
 from aiverify_test_engine.utils.json_utils import (
@@ -142,15 +143,16 @@ class AlgoInit:
                 self._initial_data_instance = copy.deepcopy(self._data_instance)
                 self._initial_model_instance = copy.deepcopy(self._model_instance)
 
-                # Perform data transformation
-                current_dataset = self._data_instance.get_data()
-                current_pipeline = self._model_instance.get_pipeline()
-                data_transformation_stages = current_pipeline[:-1]
-                transformed_dataset = data_transformation_stages.transform(current_dataset)
-                transformed_pipeline = current_pipeline[-1]
-                # Set new transformed pipeline and dataset
-                self._data_instance.set_data(transformed_dataset)
-                self._model_instance.set_pipeline(transformed_pipeline)
+                if self._model_instance.get_pipeline_plugin_type() == PipelinePluginType.SKLEARN:
+                    # Perform data transformation
+                    current_dataset = self._data_instance.get_data()
+                    current_pipeline = self._model_instance.get_pipeline()
+                    data_transformation_stages = current_pipeline[:-1]
+                    transformed_dataset = data_transformation_stages.transform(current_dataset)
+                    transformed_pipeline = current_pipeline[-1]
+                    # Set new transformed pipeline and dataset
+                    self._data_instance.set_data(transformed_dataset)
+                    self._model_instance.set_pipeline(transformed_pipeline)
 
             else:
                 # Get the data, model, and ground truth instance

--- a/stock-plugins/aiverify.stock.shap-toolbox/algorithms/shap_toolbox/README.md
+++ b/stock-plugins/aiverify.stock.shap-toolbox/algorithms/shap_toolbox/README.md
@@ -117,5 +117,9 @@ If the algorithm runs successfully, the results of the test will be saved in an 
 Run the following steps to execute the unit and integration tests inside the `tests/` folder
 
 ```sh
-docker run --entrypoint python3 aiverify-shap-toolbox -m pytest .
+docker run \
+  --entrypoint python3 \
+  -w /app/aiverify/stock-plugins/aiverify.stock.shap-toolbox/algorithms/shap_toolbox \
+  aiverify-shap-toolbox \
+  -m pytest .
 ```

--- a/stock-plugins/aiverify.stock.shap-toolbox/algorithms/shap_toolbox/aiverify_shap_toolbox/algo.py
+++ b/stock-plugins/aiverify.stock.shap-toolbox/algorithms/shap_toolbox/aiverify_shap_toolbox/algo.py
@@ -413,8 +413,8 @@ class Plugin(IAlgorithm):
         else:
             self._background = self._background_instance.get_data()
 
-        if self._model_instance.get_plugin_type() is PluginType.PIPELINE:
-            if self._model_instance.get_plugin_type() is PluginType.PIPELINE:
+        if self._model_instance.get_plugin_type() == PluginType.PIPELINE:
+            if self._model_instance.get_pipeline_plugin_type() == PipelinePluginType.SKLEARN:
                 transformers = self._model.get_pipeline()[:-1]
                 self._background = transformers.transform(self._background)
 

--- a/stock-plugins/aiverify.stock.shap-toolbox/algorithms/shap_toolbox/aiverify_shap_toolbox/algo.py
+++ b/stock-plugins/aiverify.stock.shap-toolbox/algorithms/shap_toolbox/aiverify_shap_toolbox/algo.py
@@ -13,6 +13,7 @@ from aiverify_test_engine.interfaces.ipipeline import IPipeline
 from aiverify_test_engine.interfaces.iserializer import ISerializer
 from aiverify_test_engine.plugins.enums.data_plugin_type import DataPluginType
 from aiverify_test_engine.plugins.enums.model_plugin_type import ModelPluginType
+from aiverify_test_engine.plugins.enums.pipeline_plugin_type import PipelinePluginType
 from aiverify_test_engine.plugins.enums.model_type import ModelType
 from aiverify_test_engine.plugins.enums.plugin_type import PluginType
 from aiverify_test_engine.plugins.metadata.plugin_metadata import PluginMetadata
@@ -413,8 +414,9 @@ class Plugin(IAlgorithm):
             self._background = self._background_instance.get_data()
 
         if self._model_instance.get_plugin_type() is PluginType.PIPELINE:
-            transformers = self._model.get_pipeline()[:-1]
-            self._background = transformers.transform(self._background)
+            if self._model_instance.get_plugin_type() is PluginType.PIPELINE:
+                transformers = self._model.get_pipeline()[:-1]
+                self._background = transformers.transform(self._background)
 
         # Perform data_sampling and background_sampling
         if self._data_samples > 0:

--- a/stock-plugins/aiverify.stock.shap-toolbox/algorithms/shap_toolbox/aiverify_shap_toolbox/algo_init.py
+++ b/stock-plugins/aiverify.stock.shap-toolbox/algorithms/shap_toolbox/aiverify_shap_toolbox/algo_init.py
@@ -15,6 +15,7 @@ from aiverify_test_engine.interfaces.ipipeline import IPipeline
 from aiverify_test_engine.interfaces.iserializer import ISerializer
 from aiverify_test_engine.interfaces.itestresult import ITestArguments, ITestResult
 from aiverify_test_engine.plugins.enums.model_type import ModelType
+from aiverify_test_engine.plugins.enums.pipeline_plugin_type import PipelinePluginType
 from aiverify_test_engine.plugins.enums.plugin_type import PluginType
 from aiverify_test_engine.plugins.plugins_manager import PluginManager
 from aiverify_test_engine.utils.json_utils import (
@@ -140,15 +141,16 @@ class AlgoInit:
                 self._initial_data_instance = copy.deepcopy(self._data_instance)
                 self._initial_model_instance = copy.deepcopy(self._model_instance)
 
-                # Perform data transformation
-                current_dataset = self._data_instance.get_data()
-                current_pipeline = self._model_instance.get_pipeline()
-                data_transformation_stages = current_pipeline[:-1]
-                transformed_dataset = data_transformation_stages.transform(current_dataset)
-                transformed_pipeline = current_pipeline[-1]
-                # Set new transformed pipeline and dataset
-                self._data_instance.set_data(transformed_dataset)
-                self._model_instance.set_pipeline(transformed_pipeline)
+                if self._model_instance.get_pipeline_plugin_type() == PipelinePluginType.SKLEARN:
+                    # Perform data transformation
+                    current_dataset = self._data_instance.get_data()
+                    current_pipeline = self._model_instance.get_pipeline()
+                    data_transformation_stages = current_pipeline[:-1]
+                    transformed_dataset = data_transformation_stages.transform(current_dataset)
+                    transformed_pipeline = current_pipeline[-1]
+                    # Set new transformed pipeline and dataset
+                    self._data_instance.set_data(transformed_dataset)
+                    self._model_instance.set_pipeline(transformed_pipeline)
 
             else:
                 # Get the data, model, and ground truth instance


### PR DESCRIPTION
## Description

Previously, algo_init.py applied data transformations to all pipeline types during the tabular tests, unlike scripts.algo_execute.py. This behaviour has been updated to apply transformations only to scikit-learn pipelines, ensuring compatibility with non-sklearn pipelines.

Instructions to run tests using docker have also been updated.

## Type of Change

<!-- - fix: A bug fix -->

## How to Test

All tests for the stock plugins passed (running via both venv and docker)

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [x]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
