### PR TITLE
Resolves #619

### DIFF
--- a/aiverify-test-engine-worker/src/aiverify_test_engine_worker/pipeline/pipeline_execute/kubectl_run.py
+++ b/aiverify-test-engine-worker/src/aiverify_test_engine_worker/pipeline/pipeline_execute/kubectl_run.py
@@ -101,11 +101,11 @@ class KubectlRun(Pipe):
             for key, value in json_args_dict.items():
                 if isinstance(value, str) and os.path.isabs(value) and os.path.exists(value):
                     filename = os.path.basename(value)
-                    # Replace with new path inside container
+                    # Replace with new path inside pod
                     new_path = f"/app/data/{filename}"
                     json_args_dict[key] = new_path
 
-            # Convert to JSON with properly escaped quotes
+            # Convert to JSON
             json_args = json.dumps(json_args_dict)
             
             # kubectl exec

--- a/aiverify-test-engine-worker/src/aiverify_test_engine_worker/pipeline/pipeline_execute/kubectl_run.py
+++ b/aiverify-test-engine-worker/src/aiverify_test_engine_worker/pipeline/pipeline_execute/kubectl_run.py
@@ -79,6 +79,7 @@ class KubectlRun(Pipe):
             ]
             logger.debug(f"kubectl cp model path: {cmds}")
             subprocess.run(cmds, check=True)
+            
             if task_data.ground_truth_path and task_data.task.groundTruth:
                 if task_data.ground_truth_path.samefile(task_data.data_path):
                     pod_ground_truth_path = pod_data_path
@@ -94,6 +95,19 @@ class KubectlRun(Pipe):
                     logger.debug(f"kubectl cp ground truth path: {cmds}")
                     subprocess.run(cmds, check=True)
 
+            json_args_dict = task_data.task.algorithmArgs  # This is a Python dict, not yet stringified
+
+            # Modify paths in the dict
+            for key, value in json_args_dict.items():
+                if isinstance(value, str) and os.path.isabs(value) and os.path.exists(value):
+                    filename = os.path.basename(value)
+                    # Replace with new path inside container
+                    new_path = f"/app/data/{filename}"
+                    json_args_dict[key] = new_path
+
+            # Convert to JSON with properly escaped quotes
+            json_args = json.dumps(json_args_dict)
+            
             # kubectl exec
             cmds = [
                 self.kubectl_bin,
@@ -108,7 +122,7 @@ class KubectlRun(Pipe):
                 "--data_path", pod_data_path,
                 "--model_path", pod_model_path,
                 "--model_type", task_data.task.modelType.lower(),
-                "--algorithm_args", json.dumps(task_data.task.algorithmArgs),
+                "--algorithm_args", json_args,
                 "--apigw_url", self.apigw_url,
             ]
             if task_data.ground_truth_path and task_data.task.groundTruth:


### PR DESCRIPTION
## Description

Fixed Bug #619: Paths in Algorithm Args in Technical Test Parameters were not mapped correctly to a location in the container, causing Robustness Image Test and Shap Toolbox Tests to fail.

## Type of Change

<!-- - fix: A bug fix -->

## How to Test

1. docker_run
- Build and Run AI Verify with this profile --profile automated-tests-docker --profile portal using the command below: COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose --profile portal --profile automated-tests-docker up -d
- Run Robustness Image Test and Shap Toolbox Test

2. kubectl_run
- Apply the kubectl yaml deployment files. Use test_engine_worker_kubectl.yaml
- Run Robustness Image Test and Shap Toolbox Test

3. kubectl_run2
- Apply the kubectl yaml deployment files. Use test_engine_worker_kubectl2.yaml
- Run Robustness Image Test and Shap Toolbox Test

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
